### PR TITLE
Temperature and proper bit shifting

### DIFF
--- a/examples/mpu6050.js
+++ b/examples/mpu6050.js
@@ -6,7 +6,7 @@ Cylon.robot({
 
   work: function(my) {
     every((1).seconds(), function() {
-      my.mpu6050.getMotion6(function(data) {
+      my.mpu6050.getMotionAndTemp(function(data) {
         Logger.info(data);
       });
       

--- a/lib/mpu6050.js
+++ b/lib/mpu6050.js
@@ -27,7 +27,7 @@ namespace("Cylon.Drivers.I2C", function() {
     }
 
     Mpu6050.prototype.commands = function() {
-      return ['getAngularVelocity', 'getAcceleration', 'getMotion6'];
+      return ['getAngularVelocity', 'getAcceleration', 'getMotionAndTemp'];
     };
 
     Mpu6050.prototype.start = function(callback) {
@@ -69,10 +69,10 @@ namespace("Cylon.Drivers.I2C", function() {
       if (callback == null) {
         callback = null;
       }
-      this.getMotion6(callback);
+      this.getMotionAndTemp(callback);
     };
-
-    Mpu6050.prototype.getMotion6 = function(callback) {
+	
+    Mpu6050.prototype.getMotionAndTemp = function(callback) {
       var _this = this;
 
       if (callback == null) {
@@ -80,16 +80,20 @@ namespace("Cylon.Drivers.I2C", function() {
       }
 
       this.connection.i2cRead(this.address, MPU6050_RA_ACCEL_XOUT_H, 14, function(data) {
-          var ax = (data[0] << 8) | data[1];
-          var ay = (data[2] << 8) | data[3];
-          var az = (data[4] << 8) | data[5];
-          var gx = (data[8] << 8) | data[9];
-          var gy = (data[10] << 8) | data[11];
-          var gz = (data[12] << 8) | data[13];
+          var ax = makeSignedInteger(data[0], data[1]);
+          var ay = makeSignedInteger(data[2], data[3]);
+          var az = makeSignedInteger(data[4], data[5]);
+		  
+		  var temp = makeSignedInteger(data[6], data[7]);
+          
+		  var gx = makeSignedInteger(data[8], data[9]);
+          var gy = makeSignedInteger(data[10], data[11]);
+          var gz = makeSignedInteger(data[12], data[13]);
 
         callback({
           'a': [ax,ay,az],
-          'g': [gx,gy,gz]
+          'g': [gx,gy,gz],
+		  't': convertToCelsius(temp)
         });
       });
     };
@@ -117,3 +121,29 @@ namespace("Cylon.Drivers.I2C", function() {
 
   })(Cylon.Driver);
 });
+
+// The temperature sensor is -40 to +85 degrees Celsius.
+// It is a signed integer.
+// According to the datasheet: 
+//   340 per degrees Celsius, -512 at 35 degrees.
+// At 0 degrees: -512 - (340 * 35) = -12412
+function convertToCelsius(temp) {
+	return (temp + 12412.0) / 340.0;
+}
+
+// we have high and low bits for a signed 16bit integer
+// so it has to be converted into signed 32bit integer
+function makeSignedInteger(highBits, lowBits) {
+	var minusBits = 128;
+	var leadingOnes = 4294901760;
+	
+	var value = (highBits << 8) | lowBits;
+	
+	if ((highBits & minusBits) == minusBits) {
+		// first bit is 1, so the value has to be minus
+		
+		return value | leadingOnes;
+	}
+	
+	return value;
+}


### PR DESCRIPTION
Hey Guys,

I've played a bit more with the mpu6050 driver and it turned out:

1) We were not converting the integers properly - the result from the sensor gives high and low bits for a 16bit signed integer, so the sign bit is 16th, not 32nd.

2) The sensor has a termometer - why not read it ;-) as a result I've renamed getMotion6 into getMotionAndTemp method

Now the reads are exactly the same as from plain-arduino program found here http://playground.arduino.cc/Main/MPU-6050?action=sourceblock&num=1

cc / @wojtekerbetowski @zuchos @viroos
