### PR TITLE
Add parent I2CDriver class

### DIFF
--- a/lib/blinkm.js
+++ b/lib/blinkm.js
@@ -11,6 +11,9 @@
 "use strict";
 
 var Cylon = require("cylon");
+
+var I2CDriver = require("./i2c-driver");
+
 var TO_RGB = 0x6e,
     FADE_TO_RGB = 0x63,
     FADE_TO_HSB = 0x68,
@@ -32,7 +35,7 @@ var TO_RGB = 0x6e,
  */
 var BlinkM = module.exports = function BlinkM() {
   BlinkM.__super__.constructor.apply(this, arguments);
-  this.address = 0x09;
+  this.address = this.address || 0x09;
 
   this.setupCommands([
     "goToRGB", "fadeToRGB", "fadeToHSB", "fadeToRandomRGB",
@@ -41,27 +44,7 @@ var BlinkM = module.exports = function BlinkM() {
   ]);
 };
 
-Cylon.Utils.subclass(BlinkM, Cylon.Driver);
-
-/**
- * Starts the driver
- *
- * @param {Function} callback triggered when the driver is started
- * @return {null}
- */
-BlinkM.prototype.start = function(callback) {
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-BlinkM.prototype.halt = function(callback) {
-  callback();
-};
+Cylon.Utils.subclass(BlinkM, I2CDriver);
 
 /**
  * Sets the color of the BlinkM to the specified combination of RGB values.

--- a/lib/bmp180.js
+++ b/lib/bmp180.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var BMP180_REGISTER_CALIBRATION = 0xAA,
     BMP180_REGISTER_CONTROL = 0xF4,
     BMP180_REGISTER_TEMPDATA = 0xF6,
@@ -47,7 +49,7 @@ function waitTime(mode) {
 var Bmp180 = module.exports = function Bmp180() {
   Bmp180.__super__.constructor.apply(this, arguments);
 
-  this.address = 0x77;
+  this.address = this.address || 0x77;
 
   this.commands = {
     get_pressure: this.getPressure,
@@ -56,7 +58,7 @@ var Bmp180 = module.exports = function Bmp180() {
   };
 };
 
-Cylon.Utils.subclass(Bmp180, Cylon.Driver);
+Cylon.Utils.subclass(Bmp180, I2CDriver);
 
 /**
  * Starts the driver
@@ -66,16 +68,6 @@ Cylon.Utils.subclass(Bmp180, Cylon.Driver);
  */
 Bmp180.prototype.start = function(callback) {
   this.readCoefficients(callback);
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-Bmp180.prototype.halt = function(callback) {
-  callback();
 };
 
 /**

--- a/lib/hmc6352.js
+++ b/lib/hmc6352.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 /**
  * A HMC6352 Driver
  *
@@ -19,13 +21,16 @@ var Cylon = require("cylon");
  */
 var Hmc6352 = module.exports = function Hmc6352() {
   Hmc6352.__super__.constructor.apply(this, arguments);
-  this.address = 0x42 >> 1; // to accomodate the 7-bit device addressing
+
+  // to accomodate the 7-bit device addressing
+  this.address = this.address || 0x42 >> 1;
+
   this.commands = {
     heading: this.heading
   };
 };
 
-Cylon.Utils.subclass(Hmc6352, Cylon.Driver);
+Cylon.Utils.subclass(Hmc6352, I2CDriver);
 
 /**
  * Starts the driver
@@ -35,16 +40,6 @@ Cylon.Utils.subclass(Hmc6352, Cylon.Driver);
  */
 Hmc6352.prototype.start = function(callback) {
   this.connection.i2cWrite(this.address, this.commandBytes("A"));
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-Hmc6352.prototype.halt = function(callback) {
   callback();
 };
 

--- a/lib/i2c-driver.js
+++ b/lib/i2c-driver.js
@@ -1,0 +1,29 @@
+/**
+ * Cylon.js - i2c Base Driver
+ * http://cylonjs.com
+ *
+ * Copyright (c) 2013-14 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+*/
+
+"use strict";
+
+var Cylon = require("cylon");
+
+var I2CDriver = module.exports = function I2CDriver(opts) {
+  I2CDriver.__super__.constructor.apply(this, arguments);
+
+  opts = opts || {};
+
+  this.address = opts.address;
+};
+
+Cylon.Utils.subclass(I2CDriver, Cylon.Driver);
+
+I2CDriver.prototype.start = function(callback) {
+  callback();
+};
+
+I2CDriver.prototype.halt = function(callback) {
+  callback();
+};

--- a/lib/lcd.js
+++ b/lib/lcd.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 // i2c commands
 var CLEARDISPLAY = 0x01,
     RETURNHOME = 0x02,
@@ -66,7 +68,7 @@ var En = 0x04, // Enable bit
 var LCD = module.exports = function LCD() {
   LCD.__super__.constructor.apply(this, arguments);
 
-  this.address = 0x27;
+  this.address = this.address || 0x27;
   this._backlightVal = NOBACKLIGHT;
   this._displayfunction = FOURBITMODE | TWOLINE | FIVExEIGHTDOTS;
   this._displaycontrol = DISPLAYON | CURSOROFF | BLINKOFF;
@@ -79,7 +81,7 @@ var LCD = module.exports = function LCD() {
   ]);
 };
 
-Cylon.Utils.subclass(LCD, Cylon.Driver);
+Cylon.Utils.subclass(LCD, I2CDriver);
 
 /**
  * Starts the driver
@@ -114,16 +116,6 @@ LCD.prototype.start = function(callback) {
     this._expanderWrite(this._backlightVal);
   }.bind(this));
 
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-LCD.prototype.halt = function(callback) {
   callback();
 };
 

--- a/lib/lidar-lite.js
+++ b/lib/lidar-lite.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 // Register to write to initiate ranging.
 var RegisterMeasure = 0x00,
 // Value to initiate ranging.
@@ -26,33 +28,13 @@ RegisterHighLowB = 0x8f;
  */
 var LIDARLite = module.exports = function LIDARLite() {
   LIDARLite.__super__.constructor.apply(this, arguments);
-  this.address = 0x62;
+  this.address = this.address || 0x62;
   this.commands = {
     distance: this.distance
   };
 };
 
-Cylon.Utils.subclass(LIDARLite, Cylon.Driver);
-
-/**
- * Starts the driver
- *
- * @param {Function} callback triggered when the driver is started
- * @return {null}
- */
-LIDARLite.prototype.start = function(callback) {
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-LIDARLite.prototype.halt = function(callback) {
-  callback();
-};
+Cylon.Utils.subclass(LIDARLite, I2CDriver);
 
 /**
  * Returns the distance data for the LIDAR-Lite in cm.

--- a/lib/lsm9ds0g.js
+++ b/lib/lsm9ds0g.js
@@ -4,6 +4,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var WHO_AM_I_G = 0x0F,
     CTRL_REG1_G = 0x20,
     CTRL_REG2_G = 0x21,
@@ -61,7 +63,7 @@ var G_ODR_95_BW_125  = 0x0, //   95         12.5
  */
 var LSM9DS0G = module.exports = function LSM9DS0G(opts) {
   LSM9DS0G.__super__.constructor.apply(this, arguments);
-  this.address = 0x6b;
+  this.address = this.address || 0x6b;
 
   this.scale = opts.scale || G_SCALE_245DPS;
   this.odr = opts.odr || G_ODR_95_BW_125;
@@ -71,7 +73,7 @@ var LSM9DS0G = module.exports = function LSM9DS0G(opts) {
   };
 };
 
-Cylon.Utils.subclass(LSM9DS0G, Cylon.Driver);
+Cylon.Utils.subclass(LSM9DS0G, I2CDriver);
 
 /**
  * Starts the driver
@@ -81,16 +83,6 @@ Cylon.Utils.subclass(LSM9DS0G, Cylon.Driver);
  */
 LSM9DS0G.prototype.start = function(callback) {
   this._initGyro();
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-LSM9DS0G.prototype.halt = function(callback) {
   callback();
 };
 

--- a/lib/lsm9ds0xm.js
+++ b/lib/lsm9ds0xm.js
@@ -3,6 +3,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var OUT_TEMP_L_XM = 0x05,
     OUT_TEMP_H_XM = 0x06,
     STATUS_REG_M = 0x07,
@@ -67,7 +69,7 @@ var OUT_TEMP_L_XM = 0x05,
  */
 var LSM9DS0XM = module.exports = function LSM9DS0XM() {
   LSM9DS0XM.__super__.constructor.apply(this, arguments);
-  this.address = 0x1d;
+  this.address = this.address || 0x1d;
 
   this.commands = {
     getAccel: this.getAccel,
@@ -75,7 +77,7 @@ var LSM9DS0XM = module.exports = function LSM9DS0XM() {
   };
 };
 
-Cylon.Utils.subclass(LSM9DS0XM, Cylon.Driver);
+Cylon.Utils.subclass(LSM9DS0XM, I2CDriver);
 
 /**
  * Starts the driver
@@ -86,16 +88,6 @@ Cylon.Utils.subclass(LSM9DS0XM, Cylon.Driver);
 LSM9DS0XM.prototype.start = function(callback) {
   this._initAccel();
   this._initMag();
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-LSM9DS0XM.prototype.halt = function(callback) {
   callback();
 };
 

--- a/lib/mpl115a2.js
+++ b/lib/mpl115a2.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var MPL115A2_REGISTER_PRESSURE_MSB = 0x00,
     MPL115A2_REGISTER_PRESSURE_LSB = 0x01,
     MPL115A2_REGISTER_TEMP_MSB = 0x02,
@@ -33,14 +35,14 @@ var MPL115A2_REGISTER_PRESSURE_MSB = 0x00,
  */
 var Mpl115A2 = module.exports = function Mpl115A2() {
   Mpl115A2.__super__.constructor.apply(this, arguments);
-  this.address = 0x60;
+  this.address = this.address || 0x60;
   this.commands = {
     get_pressure: this.getPressure,
     get_temperature: this.getTemperature
   };
 };
 
-Cylon.Utils.subclass(Mpl115A2, Cylon.Driver);
+Cylon.Utils.subclass(Mpl115A2, I2CDriver);
 
 /**
  * Starts the driver
@@ -50,16 +52,6 @@ Cylon.Utils.subclass(Mpl115A2, Cylon.Driver);
  */
 Mpl115A2.prototype.start = function(callback) {
   this.readCoefficients(callback);
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-Mpl115A2.prototype.halt = function(callback) {
-  callback();
 };
 
 Mpl115A2.prototype.readCoefficients = function(callback) {

--- a/lib/mpu6050.js
+++ b/lib/mpu6050.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var MPU6050_RA_ACCEL_XOUT_H = 0x3B,
     MPU6050_RA_PWR_MGMT_1 = 0x6B,
     MPU6050_PWR1_CLKSEL_BIT = 2,
@@ -38,7 +40,7 @@ var MPU6050_RA_ACCEL_XOUT_H = 0x3B,
  */
 var Mpu6050 = module.exports = function Mpu6050() {
   Mpu6050.__super__.constructor.apply(this, arguments);
-  this.address = 0x68; // DataSheet
+  this.address = this.address || 0x68; // DataSheet
   this.commands = {
     get_angular_velocity: this.getAngularVelocity,
     get_acceleration: this.getAcceleration,
@@ -46,7 +48,7 @@ var Mpu6050 = module.exports = function Mpu6050() {
   };
 };
 
-Cylon.Utils.subclass(Mpu6050, Cylon.Driver);
+Cylon.Utils.subclass(Mpu6050, I2CDriver);
 
 /**
  * Starts the driver
@@ -80,16 +82,6 @@ Mpu6050.prototype.start = function(callback) {
 
   callback();
   this.emit("start");
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-Mpu6050.prototype.halt = function(callback) {
-  callback();
 };
 
 /**

--- a/lib/pca9685.js
+++ b/lib/pca9685.js
@@ -12,6 +12,8 @@
 
 var Cylon = require("cylon");
 
+var I2CDriver = require("./i2c-driver");
+
 var PCA9685_MODE1 = 0x00,
     PCA9685_PRESCALE = 0xFE,
     PCA9685_SUBADR1 = 0x02,
@@ -33,7 +35,7 @@ var PCA9685_MODE1 = 0x00,
  */
 var PCA9685 = module.exports = function PCA9685() {
   PCA9685.__super__.constructor.apply(this, arguments);
-  this.address = 0x40;
+  this.address = this.address || 0x40;
   this.commands = {
     stop: this.stop,
     set_pwm_freq: this.setPWMFreq,
@@ -41,7 +43,7 @@ var PCA9685 = module.exports = function PCA9685() {
   };
 };
 
-Cylon.Utils.subclass(PCA9685, Cylon.Driver);
+Cylon.Utils.subclass(PCA9685, I2CDriver);
 
 /**
  * Starts the driver
@@ -52,16 +54,6 @@ Cylon.Utils.subclass(PCA9685, Cylon.Driver);
 PCA9685.prototype.start = function(callback) {
   this.connection.i2cWrite(this.address, PCA9685_MODE1, [0x00]);
   this.connection.i2cWrite(this.address, ALLLED_OFF_H, [0x10]);
-  callback();
-};
-
-/**
- * Stops the driver
- *
- * @param {Function} callback triggered when the driver is halted
- * @return {null}
- */
-PCA9685.prototype.halt = function(callback) {
   callback();
 };
 

--- a/spec/lib/i2c-driver.js
+++ b/spec/lib/i2c-driver.js
@@ -1,0 +1,40 @@
+// jshint expr:true
+"use strict";
+
+var Cylon = require("cylon");
+
+var I2CDriver = source("i2c-driver");
+
+describe("I2CDriver", function() {
+  var driver;
+
+  beforeEach(function() {
+    driver = new I2CDriver({
+      name: "mpl115a2",
+      address: 0x40
+    });
+  });
+
+  it("is a Cylon driver", function() {
+    expect(driver).to.be.an.instanceOf(I2CDriver);
+    expect(driver).to.be.an.instanceOf(Cylon.Driver);
+  });
+
+  describe("constructor", function() {
+    it("sets @address to provided value", function() {
+      expect(driver.address).to.be.eql(0x40);
+    });
+  });
+
+  it("provides a basic #start method", function() {
+    var callback = spy();
+    driver.start(callback);
+    expect(callback).to.be.called;
+  });
+
+  it("provides a basic #halt method", function() {
+    var callback = spy();
+    driver.halt(callback);
+    expect(callback).to.be.called;
+  });
+});


### PR DESCRIPTION
An alternative implementation to support https://github.com/hybridgroup/cylon-i2c/pull/33. Currently missing that PR's example.